### PR TITLE
server/new: read optionally from /etc/odkbuild/config.yml for config.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'pg', '>= 0.18'
 gem 'sinatra', '1.2.6'
 gem 'pony', '1.3'
 gem 'warden', '1.0.6'
+gem 'deep_merge', '1.1.1'
 
 gem 'riot', '0.12.1'
 gem 'mocha', '0.9.12'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     daemons (1.2.4)
+    deep_merge (1.1.1)
     eventmachine (1.2.1)
     ffi (1.0.9)
     mail (2.6.4)
@@ -46,6 +47,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  deep_merge (= 1.1.1)
   ffi (= 1.0.9)
   mocha (= 0.9.12)
   net-http-digest_auth (= 1.4)

--- a/config_manager.rb
+++ b/config_manager.rb
@@ -1,4 +1,8 @@
 require 'yaml'
+require 'deep_merge'
+
+LOCAL_CONFIG_PATH = File.join(File.dirname(__FILE__), 'config.yml')
+GLOBAL_CONFIG_PATH = '/etc/odkbuild/config.yml'
 
 class ConfigManager
   def self.[](config_key)
@@ -6,7 +10,9 @@ class ConfigManager
   end
 
   def self.load
-    @@config = (::YAML.load_file('config.yml') || {})[ENV['RACK_ENV'] || 'development']
+    env = ENV['RACK_ENV'] || 'development'
+    @@config = File.exist?(LOCAL_CONFIG_PATH) ? (::YAML.load_file('config.yml'))[env] : {}
+    @@config.deep_merge!(::YAML.load_file(GLOBAL_CONFIG_PATH)[env]) if File.exist?(GLOBAL_CONFIG_PATH)
 
     STDERR.write "WARNING: using development env because no RACK_ENV was supplied.\n" unless ENV['RACK_ENV']
     throw Exception.new "No valid RACK_ENV supplied for your config! I see: #{ENV['RACK_ENV']}" if @@config.nil?


### PR DESCRIPTION
* the config.yml file in the source directory is now also optional,
  though one of the two are required.
* the /etc file takes precedence over the file in the local source
  repository if both are present; the keys are merged in that case.