### PR TITLE
server/new: optional secure-cookie/HSTS security.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ODK Build is a web-based, drag-and-drop service for creating forms used with data collection tools such as [ODK Collect](https://opendatakit.org/use/collect/). ODK Build is part of Open Data Kit (ODK), a free and open-source set of tools which help organizations author, field, and manage mobile data collection solutions. Learn more about the Open Data Kit project and its history [here](https://opendatakit.org/about/) and read about example ODK deployments [here](https://opendatakit.org/about/deployments/).
 
-Unless you mean to do development on ODK Build, just go to [http://build.opendatakit.org](http://build.opendatakit.org) to give it a try, or to the [releases page](https://github.com/opendatakit/build/releases) to download a local copy.
+Unless you mean to do development on ODK Build, just go to [https://build.opendatakit.org](https://build.opendatakit.org) to give it a try, or to the [releases page](https://github.com/opendatakit/build/releases) to download a local copy.
 
 ## Development
 
@@ -16,7 +16,7 @@ All Rubygem dependencies are managed by Ruby Bundler. Make sure you have at leas
 
 ### Setup and Execution
 
-Now that you have resolved all the appropriate dependencies, you'll need to set up the configuration by copying `config.yml.sample` to `config.yml`. This file contains a number of secret keys and tokens, so be sure not to check it into source control once you put your own keys into it.
+Now that you have resolved all the appropriate dependencies, you'll need to set up the configuration by copying `config.yml.sample` to `config.yml`. This file contains a number of secret keys and tokens, so be sure not to check it into source control once you put your own keys into it. Note that the `cookie_ssl_only` flag should only be set to true if you are serving your requests on HTTPS; it should likely remain off for local development.
 
 Next, you want to start up your databases. You'll need to start four Tokyo Tyrant instances, one for each listing in the configuration file. If you're working from a development environment, you can do this simply by running `rake db:dev:start`, and `rake db:dev:stop` to stop them again.
 

--- a/config.ru
+++ b/config.ru
@@ -3,6 +3,7 @@ require 'bundler/setup'
 
 require 'rack'
 
+require './tls_odkbuild'
 require './warden_odkbuild'
 
 require './model/connection_manager'
@@ -17,6 +18,10 @@ AssetManager.load
 
 # middleware
 use Rack::CommonLogger
+
+if ConfigManager['cookie_ssl_only']
+  use Build::TLS
+end
 
 use Rack::Session::Cookie,
   :secret => ConfigManager['cookie_secret']

--- a/config.yml.sample
+++ b/config.yml.sample
@@ -1,5 +1,6 @@
 development:
   cookie_secret: sample
+  cookie_ssl_only: false
   database:
     host: localhost
     database: odkbuild

--- a/tls_odkbuild.rb
+++ b/tls_odkbuild.rb
@@ -1,0 +1,21 @@
+module Build
+  class TLS
+    def initialize(app, options = {})
+      @app = app
+    end
+
+    def call(env)
+      @app.call(env).tap do |response|
+        # grab headers
+        headers = response[1]
+
+        # add HSTS
+        headers['Strict-Transport-Security'] = 'max-age=778000'
+
+        # mark cookie as secure:
+        headers['Set-Cookie'] += '; secure' unless headers['Set-Cookie'].nil?
+      end
+    end
+  end
+end
+

--- a/tls_odkbuild.rb
+++ b/tls_odkbuild.rb
@@ -10,7 +10,7 @@ module Build
         headers = response[1]
 
         # add HSTS
-        headers['Strict-Transport-Security'] = 'max-age=778000'
+        headers['Strict-Transport-Security'] = 'max-age=7776000'
 
         # mark cookie as secure:
         headers['Set-Cookie'] += '; secure' unless headers['Set-Cookie'].nil?


### PR DESCRIPTION
* change the cookie_ssl_only setting to true to enable.
* this will turn on:
  * secure cookies, meaning HTTPS cookies cannot be read from HTTP.
  * HSTS with max-age of 90 days, indicating that for at least 90 days
    the site may only be accessed via HTTPS and never from HTTP.