### PR TITLE
[Issue 54] Changed aggregate instance URI from https to http

### DIFF
--- a/server/views/index.erb
+++ b/server/views/index.erb
@@ -3,7 +3,7 @@
 
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
   <head>
-    <meta http-equiv="content-type" content="text/html;charset=utf-8" /> 
+    <meta http-equiv="content-type" content="text/html;charset=utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=8" />
     <title>ODK Build</title>
 
@@ -310,9 +310,9 @@
           visible on the Internet.</p>
 
         <h4>Aggregate Instance URI</h4>
-        <p>https://<input type="text" class="aggregateInstanceName"/></p>
+        <p>http://<input type="text" class="aggregateInstanceName"/></p>
         <p>Examples include <code>https://my-aggregate.appspot.com</code> if you're on
-          Google App Engine, or <code>https://216.58.193.110:8080/ODKAggregate</code> if
+          Google App Engine, or <code>http://216.58.193.110:8080/ODKAggregate</code> if
           you have your own server on the web.</p>
         <h4>Aggregate Credentials</h4>
         <p>


### PR DESCRIPTION
Changed Aggregate instance URI from 'https://' to 'http://' and the second example to http as per discussion https://github.com/opendatakit/build/issues/54