### PR TITLE
server/bug #90: hide 'inclusive' form control where N/A

### DIFF
--- a/public/javascripts/property-editor.js
+++ b/public/javascripts/property-editor.js
@@ -15,7 +15,8 @@
         {
             var $this = $(this);
             var $editor = $('#templates .editors .' + property.type).clone();
-            $editor.attr('data-name', name);
+            $editor.attr('data-name', name).addClass('property-' + name);
+            
             $this.empty().append($editor);
 
             $.fn.propertyEditor.editors[property.type](property, $editor, $parent, name);

--- a/public/stylesheets/styles.css
+++ b/public/stylesheets/styles.css
@@ -792,7 +792,7 @@ body > .control.last .controlFlowArrow,
     background-position: 0 -30px;
 }
 
-.property-length .inclusiveCtrl {
+.property-length .inclusiveCtrl, .property-count .inclusiveCtrl {
     display: none;
 }
 

--- a/public/stylesheets/styles.css
+++ b/public/stylesheets/styles.css
@@ -792,6 +792,10 @@ body > .control.last .controlFlowArrow,
     background-position: 0 -30px;
 }
 
+.property-length .inclusiveCtrl {
+    display: none;
+}
+
 /**********
  * MODALS *
  **********/

--- a/server/views/index.erb
+++ b/server/views/index.erb
@@ -407,12 +407,12 @@
           <label for="property_range_enabled">Enable</label>
           <h5>Minimum</h5>
           <input type="text" class="editorTextfield min"/>
-          <input id="property_range_min_inclusive" type="checkbox" class="editorCheckbox inclusive minInclusive"/>
-          <label for="property_range_min_inclusive">Inclusive</label>
+          <input id="property_range_min_inclusive" type="checkbox" class="editorCheckbox inclusive minInclusive inclusiveCtrl"/>
+          <label for="property_range_min_inclusive" class="inclusiveCtrl">Inclusive</label>
           <h5>Maximum</h5>
           <input type="text" class="editorTextfield max"/>
-          <input id="property_range_max_inclusive" type="checkbox" class="editorCheckbox inclusive maxInclusive"/>
-          <label for="property_range_max_inclusive">Inclusive</label>
+          <input id="property_range_max_inclusive" type="checkbox" class="editorCheckbox inclusive maxInclusive inclusiveCtrl"/>
+          <label for="property_range_max_inclusive" class="inclusiveCtrl">Inclusive</label>
         </div>
 
         <div class="uiText">


### PR DESCRIPTION
The css targeting here feels a little messy, so I'm open to suggestions if we don't like this fix.

Also: should 'inclusive' be hidden for 'Select Multiple' fields as well?