### PR TITLE
Freeform language options

### DIFF
--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -25,7 +25,7 @@ $(function()
     $.live('.header .menu .displayLanguages a', 'click', function(event)
     {
         event.preventDefault();
-        odkmaker.i18n.displayLanguage($(this).attr('rel'));
+        odkmaker.i18n.displayLanguage($(this).closest('li').data('code'));
         $('.workspace .control').trigger('odkControl-propertiesUpdated');
     });
     $('.header .menu .toggleCollapsed').click(function(event)

--- a/public/javascripts/data.js
+++ b/public/javascripts/data.js
@@ -57,7 +57,8 @@ var dataNS = odkmaker.namespace.load('odkmaker.data');
             title: $('h1').text(),
             controls: extractRecurse($('.workspace')),
             metadata: {
-                activeLanguages: odkmaker.i18n.activeLanguages(),
+                version: odkmaker.data.currentVersion,
+                activeLanguages: odkmaker.i18n.activeLanguageData(),
                 optionsPresets: odkmaker.options.presets
             }
         };
@@ -89,8 +90,22 @@ var dataNS = odkmaker.namespace.load('odkmaker.data');
                 loadRecurse($control.find('.workspaceInner'), control.children);
         });
     };
+    // forms without a version are assumed to be version 0. any form at a version less than
+    // the current will be upgraded. to define an upgrade, add an upgrade object to any module
+    // whose keys are the number of the version to be upgraded to and values are the functions
+    // that take the form data and update it to conform with that version.
+    odkmaker.data.currentVersion = 1;
     odkmaker.data.load = function(formObj)
     {
+        var version = formObj.metadata.version || 0;
+        while (version < odkmaker.data.currentVersion)
+        {
+            formObj.metadata.version = ++version;
+            for (var module in odkmaker)
+              if ((odkmaker[module].upgrade != null) && (odkmaker[module].upgrade[version] != null))
+                  odkmaker[module].upgrade[version](formObj);
+        }
+
         $('h1').text(formObj.title);
         $('.control').trigger('odkControl-removing');
         $('.control').trigger('odkControl-removed');

--- a/public/javascripts/data.js
+++ b/public/javascripts/data.js
@@ -142,7 +142,7 @@ var dataNS = odkmaker.namespace.load('odkmaker.data');
         _.each(translations.children, function(translation)
         {
             var result = [];
-            var itext = obj[translation.attrs.lang];
+            var itext = obj[translation._languageCode];
 
             if (itext)
             {
@@ -599,10 +599,11 @@ var dataNS = odkmaker.namespace.load('odkmaker.data');
             ]
         };
 
-        _.each(odkmaker.i18n.activeLanguages(), function(language)
+        _.each(odkmaker.i18n.activeLanguages(), function(language, code)
         {
             translations.children.push({
                 name: 'translation',
+                _languageCode: code,
                 attrs: {
                     'lang': language
                 },

--- a/public/javascripts/i18n.js
+++ b/public/javascripts/i18n.js
@@ -160,6 +160,15 @@ var i18nNS = odkmaker.namespace.load('odkmaker.i18n');
             // TODO: someday make this more efficient
             $('.workspace .control.selected').trigger('odkControl-reloadProperties');
         });
+
+        $('.translationsDialog').on('change', '.translationName', function(event)
+        {
+            var $this = $(this);
+            active[$this.closest('li').data('code')] = $this.val();
+            updateMenu();
+            // TODO: someday make this more efficient
+            $('.workspace .control.selected').trigger('odkControl-reloadProperties');
+        });
     });
 
     i18nNS.upgrade = {

--- a/public/javascripts/i18n.js
+++ b/public/javascripts/i18n.js
@@ -10,7 +10,7 @@ var i18nNS = odkmaker.namespace.load('odkmaker.i18n');
 {
     var languages = { aar: 'Afar', abk: 'Abkhazian', ave: 'Avestan', afr: 'Afrikaans', aka: 'Akan', amh: 'Amharic', arg: 'Aragonese', ara: 'Arabic', asm: 'Assamese', ava: 'Avaric', aym: 'Aymara', aze: 'Azerbaijani', bak: 'Bashkir', bel: 'Belarusian', bul: 'Bulgarian', bih: 'Bihari', bis: 'Bislama', bam: 'Bambara', ben: 'Bengali', bod: 'Tibetan', bre: 'Breton', bos: 'Bosnian', cat: 'Catalan, Valencian', che: 'Chechen', cha: 'Chamorro', cos: 'Corsican', cre: 'Cree', ces: 'Czech', chu: 'Church Slavic', chv: 'Chuvash', cym: 'Welsh', dan: 'Danish', deu: 'German', div: 'Divehi', dzo: 'Dzongkha', ewe: 'Ewe', ell: 'Modern Greek', eng: 'English', epo: 'Esperanto', spa: 'Spanish', est: 'Estonian', eus: 'Basque', fas: 'Persian', ful: 'Fulah', fin: 'Finnish', fij: 'Fijian', fao: 'Faroese', fra: 'French', fry: 'Western Frisian', gle: 'Irish', gla: 'Gaelic', glg: 'Galician', grn: 'Guaraní', guj: 'Gujarati', glv: 'Manx', hau: 'Hausa', heb: 'Modern Hebrew', hin: 'Hindi', hmo: 'Hiri Motu', hrv: 'Croatian', hat: 'Haitian', hun: 'Hungarian', hye: 'Armenian', her: 'Herero', ina: 'Interlingua', ind: 'Indonesian', ile: 'Interlingue', ibo: 'Igbo', iii: 'Sichuan Yi', ipk: 'Inupiaq', ido: 'Ido', isl: 'Icelandic', ita: 'Italian', iku: 'Inuktitut', jpn: 'Japanese', jav: 'Javanese', kat: 'Georgian', kon: 'Kongo', kik: 'Kikuyu', kua: 'Kwanyama', kaz: 'Kazakh', kal: 'Kalaallisut', khm: 'Central Khmer', kan: 'Kannada', kor: 'Korean', kau: 'Kanuri', kas: 'Kashmiri', kur: 'Kurdish', kom: 'Komi', cor: 'Cornish', kir: 'Kirghiz', lat: 'Latin', ltz: 'Luxembourgish', lug: 'Ganda', lim: 'Limburgish', lin: 'Lingala', lao: 'Lao', lit: 'Lithuanian', lub: 'Luba-Katanga', lav: 'Latvian', mlg: 'Malagasy', mah: 'Marshallese', mri: 'Māori', mkd: 'Macedonian', mal: 'Malayalam', mon: 'Mongolian', mar: 'Marathi', msa: 'Malay', mlt: 'Maltese', mya: 'Burmese', nau: 'Nauru', nob: 'Norwegian Bokmål', nde: 'North Ndebele', nep: 'Nepali', ndo: 'Ndonga', nld: 'Dutch, Flemish', nno: 'Norwegian Nynorsk', nor: 'Norwegian', nbl: 'South Ndebele', nav: 'Navajo', nya: 'Chichewa', oci: 'Occitan', oji: 'Ojibwa', orm: 'Oromo', ori: 'Oriya', oss: 'Ossetian', pan: 'Panjabi', pli: 'Pāli', pol: 'Polish', pus: 'Pashto', por: 'Portuguese', que: 'Quechua', roh: 'Romansh', run: 'Rundi', ron: 'Romanian, Moldavian', rus: 'Russian', kin: 'Kinyarwanda', san: 'Sanskrit', srd: 'Sardinian', snd: 'Sindhi', sme: 'Northern Sami', sag: 'Sango', sin: 'Sinhala', slk: 'Slovak', slv: 'Slovene', smo: 'Samoan', sna: 'Shona', som: 'Somali', sqi: 'Albanian', srp: 'Serbian', ssw: 'Swati', sot: 'Southern Sotho', sun: 'Sundanese', swe: 'Swedish', swa: 'Swahili', tam: 'Tamil', tel: 'Telugu', tgk: 'Tajik', tha: 'Thai', tir: 'Tigrinya', tuk: 'Turkmen', tgl: 'Tagalog', tsn: 'Tswana', ton: 'Tonga', tur: 'Turkish', tso: 'Tsonga', tat: 'Tatar', twi: 'Twi', tah: 'Tahitian', uig: 'Uighur', ukr: 'Ukrainian', urd: 'Urdu', uzb: 'Uzbek', ven: 'Venda', vie: 'Vietnamese', vol: 'Volapük', wln: 'Walloon', wol: 'Wolof', xho: 'Xhosa', yid: 'Yiddish', yor: 'Yoruba', zha: 'Zhuang', zho: 'Chinese', zul: 'Zulu' };
 
-    var defaultLanguages = function() { return { 0: 'English', _counter: 0, _display: 0 }; };
+    var defaultLanguages = function() { return { 0: 'English', _counter: 0, _display: '0' }; };
     var active = defaultLanguages();
     i18nNS.activeLanguages = function()
     {
@@ -27,7 +27,7 @@ var i18nNS = odkmaker.namespace.load('odkmaker.i18n');
         updateMenu();
     };
 
-    var display = 0;
+    var display = '0';
     i18nNS.displayLanguage = function(value)
     {
         if (value !== undefined)
@@ -108,7 +108,7 @@ var i18nNS = odkmaker.namespace.load('odkmaker.i18n');
             if (_.any(_.values(active), function(activeLang) { return language === activeLang; }))
                 return;
 
-            var code = ++active._counter;
+            var code = (++active._counter).toString();
             active[code] = language;
 
             // update dialog ui

--- a/public/javascripts/i18n.js
+++ b/public/javascripts/i18n.js
@@ -8,220 +8,40 @@ var i18nNS = odkmaker.namespace.load('odkmaker.i18n');
 
 ;(function($)
 {
-    var languages = {
-      aar: 'Afar',
-      abk: 'Abkhazian',
-      ave: 'Avestan',
-      afr: 'Afrikaans',
-      aka: 'Akan',
-      amh: 'Amharic',
-      arg: 'Aragonese',
-      ara: 'Arabic',
-      asm: 'Assamese',
-      ava: 'Avaric',
-      aym: 'Aymara',
-      aze: 'Azerbaijani',
-      bak: 'Bashkir',
-      bel: 'Belarusian',
-      bul: 'Bulgarian',
-      bih: 'Bihari',
-      bis: 'Bislama',
-      bam: 'Bambara',
-      ben: 'Bengali',
-      bod: 'Tibetan',
-      bre: 'Breton',
-      bos: 'Bosnian',
-      cat: 'Catalan, Valencian',
-      che: 'Chechen',
-      cha: 'Chamorro',
-      cos: 'Corsican',
-      cre: 'Cree',
-      ces: 'Czech',
-      chu: 'Church Slavic',
-      chv: 'Chuvash',
-      cym: 'Welsh',
-      dan: 'Danish',
-      deu: 'German',
-      div: 'Divehi',
-      dzo: 'Dzongkha',
-      ewe: 'Ewe',
-      ell: 'Modern Greek',
-      eng: 'English',
-      epo: 'Esperanto',
-      spa: 'Spanish',
-      est: 'Estonian',
-      eus: 'Basque',
-      fas: 'Persian',
-      ful: 'Fulah',
-      fin: 'Finnish',
-      fij: 'Fijian',
-      fao: 'Faroese',
-      fra: 'French',
-      fry: 'Western Frisian',
-      gle: 'Irish',
-      gla: 'Gaelic',
-      glg: 'Galician',
-      grn: 'Guaraní',
-      guj: 'Gujarati',
-      glv: 'Manx',
-      hau: 'Hausa',
-      heb: 'Modern Hebrew',
-      hin: 'Hindi',
-      hmo: 'Hiri Motu',
-      hrv: 'Croatian',
-      hat: 'Haitian',
-      hun: 'Hungarian',
-      hye: 'Armenian',
-      her: 'Herero',
-      ina: 'Interlingua',
-      ind: 'Indonesian',
-      ile: 'Interlingue',
-      ibo: 'Igbo',
-      iii: 'Sichuan Yi',
-      ipk: 'Inupiaq',
-      ido: 'Ido',
-      isl: 'Icelandic',
-      ita: 'Italian',
-      iku: 'Inuktitut',
-      jpn: 'Japanese',
-      jav: 'Javanese',
-      kat: 'Georgian',
-      kon: 'Kongo',
-      kik: 'Kikuyu',
-      kua: 'Kwanyama',
-      kaz: 'Kazakh',
-      kal: 'Kalaallisut',
-      khm: 'Central Khmer',
-      kan: 'Kannada',
-      kor: 'Korean',
-      kau: 'Kanuri',
-      kas: 'Kashmiri',
-      kur: 'Kurdish',
-      kom: 'Komi',
-      cor: 'Cornish',
-      kir: 'Kirghiz',
-      lat: 'Latin',
-      ltz: 'Luxembourgish',
-      lug: 'Ganda',
-      lim: 'Limburgish',
-      lin: 'Lingala',
-      lao: 'Lao',
-      lit: 'Lithuanian',
-      lub: 'Luba-Katanga',
-      lav: 'Latvian',
-      mlg: 'Malagasy',
-      mah: 'Marshallese',
-      mri: 'Māori',
-      mkd: 'Macedonian',
-      mal: 'Malayalam',
-      mon: 'Mongolian',
-      mar: 'Marathi',
-      msa: 'Malay',
-      mlt: 'Maltese',
-      mya: 'Burmese',
-      nau: 'Nauru',
-      nob: 'Norwegian Bokmål',
-      nde: 'North Ndebele',
-      nep: 'Nepali',
-      ndo: 'Ndonga',
-      nld: 'Dutch, Flemish',
-      nno: 'Norwegian Nynorsk',
-      nor: 'Norwegian',
-      nbl: 'South Ndebele',
-      nav: 'Navajo',
-      nya: 'Chichewa',
-      oci: 'Occitan',
-      oji: 'Ojibwa',
-      orm: 'Oromo',
-      ori: 'Oriya',
-      oss: 'Ossetian',
-      pan: 'Panjabi',
-      pli: 'Pāli',
-      pol: 'Polish',
-      pus: 'Pashto',
-      por: 'Portuguese',
-      que: 'Quechua',
-      roh: 'Romansh',
-      run: 'Rundi',
-      ron: 'Romanian, Moldavian',
-      rus: 'Russian',
-      kin: 'Kinyarwanda',
-      san: 'Sanskrit',
-      srd: 'Sardinian',
-      snd: 'Sindhi',
-      sme: 'Northern Sami',
-      sag: 'Sango',
-      sin: 'Sinhala',
-      slk: 'Slovak',
-      slv: 'Slovene',
-      smo: 'Samoan',
-      sna: 'Shona',
-      som: 'Somali',
-      sqi: 'Albanian',
-      srp: 'Serbian',
-      ssw: 'Swati',
-      sot: 'Southern Sotho',
-      sun: 'Sundanese',
-      swe: 'Swedish',
-      swa: 'Swahili',
-      tam: 'Tamil',
-      tel: 'Telugu',
-      tgk: 'Tajik',
-      tha: 'Thai',
-      tir: 'Tigrinya',
-      tuk: 'Turkmen',
-      tgl: 'Tagalog',
-      tsn: 'Tswana',
-      ton: 'Tonga',
-      tur: 'Turkish',
-      tso: 'Tsonga',
-      tat: 'Tatar',
-      twi: 'Twi',
-      tah: 'Tahitian',
-      uig: 'Uighur',
-      ukr: 'Ukrainian',
-      urd: 'Urdu',
-      uzb: 'Uzbek',
-      ven: 'Venda',
-      vie: 'Vietnamese',
-      vol: 'Volapük',
-      wln: 'Walloon',
-      wol: 'Wolof',
-      xho: 'Xhosa',
-      yid: 'Yiddish',
-      yor: 'Yoruba',
-      zha: 'Zhuang',
-      zho: 'Chinese',
-      zul: 'Zulu'
-    };
+    var languages = { aar: 'Afar', abk: 'Abkhazian', ave: 'Avestan', afr: 'Afrikaans', aka: 'Akan', amh: 'Amharic', arg: 'Aragonese', ara: 'Arabic', asm: 'Assamese', ava: 'Avaric', aym: 'Aymara', aze: 'Azerbaijani', bak: 'Bashkir', bel: 'Belarusian', bul: 'Bulgarian', bih: 'Bihari', bis: 'Bislama', bam: 'Bambara', ben: 'Bengali', bod: 'Tibetan', bre: 'Breton', bos: 'Bosnian', cat: 'Catalan, Valencian', che: 'Chechen', cha: 'Chamorro', cos: 'Corsican', cre: 'Cree', ces: 'Czech', chu: 'Church Slavic', chv: 'Chuvash', cym: 'Welsh', dan: 'Danish', deu: 'German', div: 'Divehi', dzo: 'Dzongkha', ewe: 'Ewe', ell: 'Modern Greek', eng: 'English', epo: 'Esperanto', spa: 'Spanish', est: 'Estonian', eus: 'Basque', fas: 'Persian', ful: 'Fulah', fin: 'Finnish', fij: 'Fijian', fao: 'Faroese', fra: 'French', fry: 'Western Frisian', gle: 'Irish', gla: 'Gaelic', glg: 'Galician', grn: 'Guaraní', guj: 'Gujarati', glv: 'Manx', hau: 'Hausa', heb: 'Modern Hebrew', hin: 'Hindi', hmo: 'Hiri Motu', hrv: 'Croatian', hat: 'Haitian', hun: 'Hungarian', hye: 'Armenian', her: 'Herero', ina: 'Interlingua', ind: 'Indonesian', ile: 'Interlingue', ibo: 'Igbo', iii: 'Sichuan Yi', ipk: 'Inupiaq', ido: 'Ido', isl: 'Icelandic', ita: 'Italian', iku: 'Inuktitut', jpn: 'Japanese', jav: 'Javanese', kat: 'Georgian', kon: 'Kongo', kik: 'Kikuyu', kua: 'Kwanyama', kaz: 'Kazakh', kal: 'Kalaallisut', khm: 'Central Khmer', kan: 'Kannada', kor: 'Korean', kau: 'Kanuri', kas: 'Kashmiri', kur: 'Kurdish', kom: 'Komi', cor: 'Cornish', kir: 'Kirghiz', lat: 'Latin', ltz: 'Luxembourgish', lug: 'Ganda', lim: 'Limburgish', lin: 'Lingala', lao: 'Lao', lit: 'Lithuanian', lub: 'Luba-Katanga', lav: 'Latvian', mlg: 'Malagasy', mah: 'Marshallese', mri: 'Māori', mkd: 'Macedonian', mal: 'Malayalam', mon: 'Mongolian', mar: 'Marathi', msa: 'Malay', mlt: 'Maltese', mya: 'Burmese', nau: 'Nauru', nob: 'Norwegian Bokmål', nde: 'North Ndebele', nep: 'Nepali', ndo: 'Ndonga', nld: 'Dutch, Flemish', nno: 'Norwegian Nynorsk', nor: 'Norwegian', nbl: 'South Ndebele', nav: 'Navajo', nya: 'Chichewa', oci: 'Occitan', oji: 'Ojibwa', orm: 'Oromo', ori: 'Oriya', oss: 'Ossetian', pan: 'Panjabi', pli: 'Pāli', pol: 'Polish', pus: 'Pashto', por: 'Portuguese', que: 'Quechua', roh: 'Romansh', run: 'Rundi', ron: 'Romanian, Moldavian', rus: 'Russian', kin: 'Kinyarwanda', san: 'Sanskrit', srd: 'Sardinian', snd: 'Sindhi', sme: 'Northern Sami', sag: 'Sango', sin: 'Sinhala', slk: 'Slovak', slv: 'Slovene', smo: 'Samoan', sna: 'Shona', som: 'Somali', sqi: 'Albanian', srp: 'Serbian', ssw: 'Swati', sot: 'Southern Sotho', sun: 'Sundanese', swe: 'Swedish', swa: 'Swahili', tam: 'Tamil', tel: 'Telugu', tgk: 'Tajik', tha: 'Thai', tir: 'Tigrinya', tuk: 'Turkmen', tgl: 'Tagalog', tsn: 'Tswana', ton: 'Tonga', tur: 'Turkish', tso: 'Tsonga', tat: 'Tatar', twi: 'Twi', tah: 'Tahitian', uig: 'Uighur', ukr: 'Ukrainian', urd: 'Urdu', uzb: 'Uzbek', ven: 'Venda', vie: 'Vietnamese', vol: 'Volapük', wln: 'Walloon', wol: 'Wolof', xho: 'Xhosa', yid: 'Yiddish', yor: 'Yoruba', zha: 'Zhuang', zho: 'Chinese', zul: 'Zulu' };
 
-    var active = ['eng'];
+    var defaultLanguages = function() { return { 0: 'English', _counter: 0, _display: 0 }; };
+    var active = defaultLanguages();
     i18nNS.activeLanguages = function()
+    {
+        return _.omit(active, function(_, code) { return /^_/.test(code); });
+    };
+    i18nNS.activeLanguageData = function()
     {
         return active;
     };
     i18nNS.setActiveLanguages = function(newActive)
     {
-        active = newActive || ['eng'];
+        active = newActive || defaultLanguages();
+        i18nNS.displayLanguage(active._display);
+        updateMenu();
     };
 
-    var display = 'eng';
+    var display = 0;
     i18nNS.displayLanguage = function(value)
     {
         if (value !== undefined)
-            display = value;
+            active._display = display = value;
 
         return display;
     };
 
-    i18nNS.getFriendlyName = function(code)
-    {
-        return languages[code];
-    };
-
     var createTranslationRow = function(code, name)
     {
-        return $('<li class="' + code + '"><a href="#remove" class="removeTranslation">remove</a>' + name + '</li>');
+        var result = $('<li><a href="#remove" class="removeTranslation">remove</a><input type="text" class="translationName"/></li>');
+        result.data('code', code);
+        result.find('input').val(name);
+        return result;
     };
 
     var getTranslateProperties = function()
@@ -244,17 +64,26 @@ var i18nNS = odkmaker.namespace.load('odkmaker.i18n');
         $dialog.find('.translationNone').show();
 
         var $list = $dialog.find('.translationList').empty();
-        _.each(active, function(code)
+        _.each(i18nNS.activeLanguages(), function(language, code)
         {
             $dialog.find('.translationNone').hide();
-            $list.append(createTranslationRow(code, languages[code]));
+            $list.append(createTranslationRow(code, language));
         });
+    };
 
-        var $select = $dialog.find('.translationSelect').empty();
-        _.each(languages, function(name, code)
+    var updateMenu = function()
+    {
+        // dump and reconstruct
+        var $menu = $('.menu .displayLanguages');
+        $menu.empty();
+
+        _.each(i18nNS.activeLanguages(), function(language, code)
         {
-            if ($.inArray(code, active) < 0)
-                $select.append('<option value="' + code + '">' + name + '</option>');
+            var item = $('<li class="radio"><a href="#" rel="' + $.h(code) + '"><span class="icon"/>' +
+                $.h(language) + '</span></a></li>');
+            item.toggleClass('selected', display === code);
+            item.data('code', code);
+            $menu.append(item);
         });
     };
 
@@ -272,23 +101,28 @@ var i18nNS = odkmaker.namespace.load('odkmaker.i18n');
             event.preventDefault();
 
             // get selected option
-            var $selectedOption = $('.translationSelect :selected');
-            var languageKey = $selectedOption.attr('value');
-            active.push(languageKey);
+            var $textbox = $('.translationsDialog .translationNewName');
+            var language = $textbox.val().trim();
+
+            // bail out if we already have this language
+            if (_.any(_.values(active), function(activeLang) { return language === activeLang; }))
+                return;
+
+            var code = ++active._counter;
+            active[code] = language;
 
             // update dialog ui
-            $('.translationsDialog .translationList').append(createTranslationRow(languageKey, languages[languageKey]));
-            $selectedOption.remove();
+            $('.translationsDialog .translationList').append(createTranslationRow(code, language));
+            $textbox.val('');
             $('.translationsDialog .translationNone').hide();
 
             // update active translations menu
-            $('.displayLanguages').append('<li class="radio"><a href="#" rel="' + languageKey + '"><span class="icon"></span>' +
-                languages[languageKey] + '</a></li>');
+            updateMenu();
 
             // update underlying data and visible property ui
             _.each(getTranslateProperties(), function(property)
             {
-                property.value[languageKey] = '';
+                property.value[code] = '';
             });
             // TODO: someday make this more efficient
             $('.workspace .control.selected').trigger('odkControl-reloadProperties');
@@ -301,27 +135,41 @@ var i18nNS = odkmaker.namespace.load('odkmaker.i18n');
             var $this = $(this);
 
             // get item to remove
-            var languageKey = $this.closest('li').attr('class');
+            var code = $this.closest('li').data('code');
 
-            if (!confirm('Are you sure you want to delete the active language ' + languages[languageKey] +
+            if (!confirm('Are you sure you want to delete the active language ' + active[code] +
                          '? All existing translations for this language will be lost!'))
                 return;
 
-            $.removeFromArray(languageKey,active);
-            display = active[0];
+            delete active[code];
+            if (display == code)
+            {
+                display = _.keys(i18nNS.activeLanguages())[0];
+                $('.workspace .control').trigger('odkControl-propertiesUpdated');
+            }
 
-            // update dialog ui
-            $('.translationSelect').append($('<option value="' + languageKey + '">' + languages[languageKey] + '</option>'));
+            // update dialog and menu
             $this.closest('li').remove();
+            updateMenu();
 
             // update underlying data and visible property ui
             _.each(getTranslateProperties(), function(property)
             {
-                delete property.value[languageKey];
+                delete property.value[code];
             });
             // TODO: someday make this more efficient
             $('.workspace .control.selected').trigger('odkControl-reloadProperties');
         });
     });
+
+    i18nNS.upgrade = {
+        1: function(form) {
+            var activeLanguages = form.metadata.activeLanguages;
+            var mappedLanguages = { _counter: 0, _display: activeLanguages[0] };
+            for (var i = 0; i < activeLanguages.length; i++)
+                mappedLanguages[activeLanguages[i]] = languages[activeLanguages[i]];
+            form.metadata.activeLanguages = mappedLanguages;
+        }
+    };
 })(jQuery);
 

--- a/public/javascripts/options-editor.js
+++ b/public/javascripts/options-editor.js
@@ -182,9 +182,9 @@ var optionsNS = odkmaker.namespace.load('odkmaker.options');
     {
         // get languages
         var languages = [{ id: 'value', name: 'Underlying Value'}].concat(
-            _.map(odkmaker.i18n.activeLanguages(), function(lang)
+            _.map(odkmaker.i18n.activeLanguages(), function(lang, code)
             {
-                return { id: lang, name: odkmaker.i18n.activeLanguages()[lang] };
+                return { id: code, name: lang };
             }));
 
         // update ui
@@ -202,7 +202,7 @@ var optionsNS = odkmaker.namespace.load('odkmaker.options');
                 langOptions = _.map(source, function(property) { return property.text[lang.id] || ''; });
             langOptions.push(''); // add an empty row at the end
 
-            var $listItem = $('<li data-lang="' + lang.id + '"/>');
+            var $listItem = $('<li data-lang="' + $.h(lang.id) + '"/>');
             _.each(langOptions, function(langOption)
             {
                 $listItem.append('<input type="text" value="' + $.h(langOption) + '"/>');

--- a/public/javascripts/options-editor.js
+++ b/public/javascripts/options-editor.js
@@ -184,7 +184,7 @@ var optionsNS = odkmaker.namespace.load('odkmaker.options');
         var languages = [{ id: 'value', name: 'Underlying Value'}].concat(
             _.map(odkmaker.i18n.activeLanguages(), function(lang)
             {
-                return { id: lang, name: odkmaker.i18n.getFriendlyName(lang) };
+                return { id: lang, name: odkmaker.i18n.activeLanguages()[lang] };
             }));
 
         // update ui

--- a/public/javascripts/property-editor.js
+++ b/public/javascripts/property-editor.js
@@ -68,17 +68,15 @@
             $editor.find('p').text(property.description);
 
             var $translationsList = $editor.find('.translations');
-            _.each(odkmaker.i18n.activeLanguages(), function(language)
+            _.each(odkmaker.i18n.activeLanguages(), function(language, code)
             {
-                var languageKey = language;
-
                 var $newRow = $('#templates .editors .uiText-translation').clone();
-                $newRow.find('h5').text(odkmaker.i18n.getFriendlyName(languageKey));
+                $newRow.find('h5').text(language);
                 $newRow.find('.editorTextfield')
-                    .val((property.value == null) ? '' : (property.value[languageKey] || ''))
+                    .val((property.value == null) ? '' : (property.value[code] || ''))
                     .bind('keyup input', function(event)
                     {
-                        property.value[languageKey] = $(this).val();
+                        property.value[code] = $(this).val();
                         $parent.trigger('odkControl-propertiesUpdated', [ property.id ]);
                     });
                 $translationsList.append($newRow);

--- a/server/odkbuild_server.rb
+++ b/server/odkbuild_server.rb
@@ -222,6 +222,20 @@ class OdkBuild < Sinatra::Application
     return result
   end
 
+  # bounce a payload through to a local build2xlsform instance for dev env. in prod, this ought
+  # to be done at the apache/nginx/etc level via proxypass.
+  post '/convert' do
+    http = Net::HTTP.new('localhost', 8686)
+    req = Net::HTTP::Post.new('/convert')
+    req['Content-Type'] = 'application/json'
+    req.body = request.body.read.to_s
+
+    res = http.request(req)
+
+    status 200
+    return res.body
+  end
+
   # bounce a payload through the server to aggregate
   post '/aggregate/post' do
     # make sure we're good to go

--- a/server/views/index.erb
+++ b/server/views/index.erb
@@ -268,7 +268,7 @@
         <ul class="translationList"></ul>
 
         <h4>Add a new language</h4>
-        <select class="translationSelect"></select>
+        <input type="text" class="translationNewName"/>
         <a class="addTranslation" href="#addTranslation">Add Translation</a>
       </div>
       <div class="modalButtonContainer">


### PR DESCRIPTION
Allows users to type their own language names rather than selecting from the list of ISO-languages, which resolves #55. This PR also fixes #91.

Previously, languages were stored as an array of ISO codes. The strategy here is to move from an array to a hash mapping, and for custom new languages to generate integer codes. So a typical migrated `activeLanguages` databag might look like `{ _counter: 2, _display: "eng", eng: "English", esp: "Spanish", 0: "Cool Language", 1: "Cooler Language" }`. The `_counter` key stores the current increment count for generating integer codes, and the `_display` key keeps track of which language the user has active from the View menu.

As a side effect, the outputted language to XML and to XLSForm is now the full language name rather than a three-letter ISO-code. This means that in Collect it'll display the language name rather than the code as well, but it also means dirty text (whitespace, etc) can get into the XML attributes/XLSForm headers. Having checked with the XLSForm reftable, ODK Validate, and a cursory look at the ODK Collect codebase, I don't believe this should pose a problem, but y'all'd know better than me.