### PR TITLE
data/bug #63: form name not updated after save-as operation.

### DIFF
--- a/public/javascripts/data-ui.js
+++ b/public/javascripts/data-ui.js
@@ -192,6 +192,7 @@ var dataNS = odkmaker.namespace.load('odkmaker.data');
                     $.toast('Your form has been saved as "' + title + '".');
                     dataNS.currentForm = response;
                     dataNS.clean = true;
+                    $('h1').text(title);
                     $('.saveAsDialog').jqmHide();
                 },
                 error: function(request, status, error)


### PR DESCRIPTION
* this includes implicit save-as when saving an unsaved form.
* contrary to the description of #63, code audit and testing reveals
  that Build does indeed switch to the new form (save as; make change;
  save that; reload original and verify it is untouched).
* Fixes #63, Fixes #60.