### PR TITLE
styles/bug: bottom toolpane could get overlapped with narrow windows.

### DIFF
--- a/public/stylesheets/styles.css
+++ b/public/stylesheets/styles.css
@@ -997,6 +997,30 @@ body > .control.last .controlFlowArrow,
     padding: 0.2em 0.4em;
 }
 
+/* pop the help pane up just a bit to make room for toolbar controls */
+@media(max-width: 1125px)
+{
+    .helpPane { bottom: 3em; }
+    .propertiesPane { margin-bottom: 3.5em; }
+
+    .suppressInformation .propertiesPane { bottom: 3em !important; }
+}
+
+/* hide "Add new" text to make yet more room */
+@media(max-width: 830px)
+{
+    .toolPalette h3 { display: none; }
+}
+
+/* compress spacing/margins to make even more room */
+@media(max-width: 775px)
+{
+    .toolPalette ul li { margin-left: 0.5em; }
+    .toolPalette ul li.separator { display: none; }
+}
+
+/* any smaller (~<650px) and the layout is impractical on more general terms so forget it. */
+
 /**********
  * MODALS *
  **********/


### PR DESCRIPTION
* use (shiny new) css media queries to gracefully degrade as window
  narrows:
  * first pop the info/prop pane up.
  * Then remove the "Add new" text (leave the + icon).
  * Finally compress the padding between toolpane buttons.
  * Any further and the UI is useless for other reasons.