### PR TITLE
ui/bug #138: was no longer remembering advanced expansion state.

### DIFF
--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -79,16 +79,6 @@ $(function()
     // Kick off a new form by default
     applicationNS.newForm();
 
-    // Toggles
-    $('body').on('click', 'a.toggle', function(event)
-    {
-        event.preventDefault();
-        $(this)
-            .toggleClass('expanded')
-            .siblings('.toggleContainer')
-                .slideToggle('normal');
-    });
-
     // External links should open in a new window
     $("a[rel$='external']").click(function()
     {

--- a/public/javascripts/control.js
+++ b/public/javascripts/control.js
@@ -16,16 +16,15 @@
     var drawPropertyList = function($this, properties)
     {
             // clear out and reconstruct property list
-            var wasExpanded = $propertyList.find('.advanced > .toggle').hasClass('expanded');
             $propertyList.empty();
 
             var $advancedContainer = $.tag({
                 _: 'li', 'class': 'advanced', contents: [
-                    { _: 'a', 'class': [ 'toggle', { i: wasExpanded, t: 'expanded' } ], href: '#advanced', contents: [
+                    { _: 'a', 'class': 'toggle', href: '#advanced', contents: [
                         { _: 'div', 'class': 'icon' },
                         'Advanced'
                     ] },
-                    { _: 'ul', 'class': 'advancedProperties toggleContainer', style: { display: { i: wasExpanded, t: 'block', e: 'none' } } }
+                    { _: 'ul', 'class': 'advancedProperties toggleContainer' }
                 ]
             });
             var $advancedList = $advancedContainer.find('.advancedProperties');
@@ -59,6 +58,16 @@
         else if ($selected.length === 1)
             drawPropertyList($selected.eq(0), $selected.eq(0).data('odkControl-properties'));
     } });
+
+    // Wired events
+    $(function()
+    {
+        $propertyList.on('click', '.toggle', function(event)
+        {
+            event.preventDefault();
+            $propertyList.toggleClass('showAdvanced');
+        });
+    });
 
     // Private methods
 

--- a/public/stylesheets/styles.css
+++ b/public/stylesheets/styles.css
@@ -864,16 +864,34 @@ body > .control.last .controlFlowArrow,
 {
     font-size: 1.1em;
 }
+.propertiesPane .propertyList li.advanced
+{
+    padding-left: 0;
+}
 .propertiesPane .propertyList li.advanced a.toggle
 {
     color: #444;
     font-size: 1.4em;
     letter-spacing: -1px;
-    margin-left: -0.714em;
 }
 .propertiesPane .advancedProperties
 {
+    max-height: 0;
+    overflow: hidden;
     padding-top: 1em;
+    transition: 0.4s max-height;
+}
+.propertiesPane .advancedProperties .propertyItem
+{
+    padding-left: 1em;
+}
+.propertiesPane .propertyList input[type="text"]
+{
+    width: calc(100% - 1em);
+}
+.propertiesPane .propertyList.showAdvanced .advancedProperties
+{
+    max-height: 20em
 }
 
 .propertiesPane .propertyList li .optionsList
@@ -925,7 +943,7 @@ body > .control.last .controlFlowArrow,
 {
     content: '\e901';
 }
-.propertiesPane .propertyList li.advanced .expanded .icon:before
+.propertiesPane .propertyList.showAdvanced li.advanced .icon:before
 {
     content: '\e900';
 }


### PR DESCRIPTION
* track with a node className rather than a local var, and then apply
  css on the className instead.
* was only using the generic toggle/toggleContainer code in one spot, so
  eliminate that generic code.
* resolves #138.