### PR TITLE
control/new+bug #123: update text and behaviour around Invalid Text.

### DIFF
--- a/public/javascripts/control.js
+++ b/public/javascripts/control.js
@@ -257,12 +257,19 @@
 
             // Deep clone the properties if relevant
             var properties = null;
-            if ((type == 'group') || (type == 'branch') || (type == 'metadata'))
-                properties = defaultProperties || $.extend(true, {}, $.fn.odkControl.controlProperties[type]);
+
+            if (defaultProperties != null)
+                properties = defaultProperties;
+            else if ((type == 'group') || (type == 'branch') || (type == 'metadata'))
+                properties = $.extend(true, {}, $.fn.odkControl.controlProperties[type]);
             else
-                properties = defaultProperties ||
-                    $.extend(true, $.extend(true, {}, $.fn.odkControl.defaultProperties),
-                                   $.fn.odkControl.controlProperties[type]);
+            {
+                properties = $.extend(true, {}, $.fn.odkControl.defaultProperties);
+                var controlProperties = $.fn.odkControl.controlProperties[type];
+                for (var prop in controlProperties)
+                    delete properties[prop];
+                $.extend(true, properties, controlProperties);
+            }
 
             var match = null;
             if (properties.name.value == 'untitled')
@@ -398,8 +405,18 @@
         constraint:   { name: 'Constraint',
                         type: 'text',
                         description: 'Specify a custom expression to validate the user input.',
-                        tips: [ 'The <a href="https://opendatakit.github.io/xforms-spec/#xpath-functions" rel="external">ODK XForms Functions Spec</a> may be useful.' ],
+                        tips: [
+                            'The <a href="https://opendatakit.github.io/xforms-spec/#xpath-functions" rel="external">ODK XForms Functions Spec</a> may be useful.',
+                            'If this constraint check fails, the Invalid Text is displayed.'
+                        ],
                         value: '',
+                        advanced: true,
+                        summary: false },
+        // this is automatically overridden by controls that have their own specified invalidText:
+        invalidText:  { name: 'Constraint Invalid Text',
+                        type: 'uiText',
+                        description: 'Message to display if the value fails the custom constraint check.',
+                        value: {},
                         advanced: true,
                         summary: false },
         destination:  { name: 'Instance Destination',
@@ -432,6 +449,7 @@
           invalidText:{ name: 'Invalid Text',
                         type: 'uiText',
                         description: 'Message to display if the value fails the length check.',
+                        tips: [ 'It is also displayed if a custom constraint check is failed.' ],
                         value: {},
                         summary: false } },
         inputNumeric: {
@@ -446,6 +464,7 @@
           invalidText:{ name: 'Invalid Text',
                         type: 'uiText',
                         description: 'Message to display if the value fails the range check.',
+                        tips: [ 'It is also displayed if a custom constraint check is failed.' ],
                         value: {},
                         summary: false },
           kind:       { name: 'Kind',
@@ -468,6 +487,7 @@
           invalidText:{ name: 'Invalid Text',
                         type: 'uiText',
                         description: 'Message to display if the value fails the range check.',
+                        tips: [ 'It is also displayed if a custom constraint check is failed.' ],
                         value: {},
                         summary: false },
           kind:       { name: 'Kind',
@@ -535,6 +555,12 @@
                             'For an open-ended range, fill in only a minimum or a maximum and leave the other blank.' ],
                         value: false,
                         summary: true },
+          invalidText:{ name: 'Invalid Text',
+                        type: 'uiText',
+                        description: 'Message to display if the value fails the response count check.',
+                        tips: [ 'It is also displayed if a custom constraint check is failed.' ],
+                        value: {},
+                        summary: false },
           appearance: { name: 'Style',
                         type: 'enum',
                         description: 'What interface to present.',


### PR DESCRIPTION
* now makes explicit that a custom constraint check failure will trigger
  the message.
* select multiple control types now get an Invalid Text property field.
* all control types that don’t have a toplevel Invalid Text field now
  automatically have one under advanced just below the custom Constraint
  definition field.
* resolves #123.