### PR TITLE
export/new #56: allow title-on-phone to differ from title-in-Build.

### DIFF
--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -12,6 +12,7 @@ applicationNS.newForm = function()
     $('.control').trigger('odkControl-removed');
     $('.workspace').empty();
     $('.header h1').text('Untitled Form');
+    $('#formProperties_title').val('');
     applicationNS.clearProperties();
     odkmaker.data.currentForm = null;
     odkmaker.data.clean = true;

--- a/public/javascripts/data-ui.js
+++ b/public/javascripts/data-ui.js
@@ -286,5 +286,13 @@ var dataNS = odkmaker.namespace.load('odkmaker.data');
                 complete: function() { $loading.hide(); }
             });
         });
+
+        $('.formPropertiesDialog .jqmClose').on('click', function()
+        {
+            // this codebase is really starting to wear. we have to clear out this field
+            // if it is identical to the main title so it doesn't get picked up.
+            var $input = $('#formProperties_title');
+            if ($input.val() === $('h1').text()) $input.val('');
+        });
     });
 })(jQuery);

--- a/public/javascripts/data.js
+++ b/public/javascripts/data.js
@@ -34,15 +34,26 @@ var dataNS = odkmaker.namespace.load('odkmaker.data');
     };
     odkmaker.data.extract = function()
     {
+        var htitle = odkmaker.data.getTitle();
+        if ($.isBlank(htitle) || (htitle === $('h1').text())) htitle = null;
+
         return {
             title: $('h1').text(),
             controls: extractMany($('.workspace')),
             metadata: {
                 version: odkmaker.data.currentVersion,
                 activeLanguages: odkmaker.i18n.activeLanguageData(),
-                optionsPresets: odkmaker.options.presets
+                optionsPresets: odkmaker.options.presets,
+                htitle: htitle
             }
         };
+    };
+    odkmaker.data.getTitle = function()
+    {
+        var title = $('#formProperties_title').val();
+        if ($.isBlank(title) && (odkmaker.data.currentForm != null)) title = odkmaker.data.currentForm.metadata.title;
+        if ($.isBlank(title)) title = $('h1').text();
+        return title;
     };
 
     var loadOne = odkmaker.data.loadOne = function(control)
@@ -94,6 +105,7 @@ var dataNS = odkmaker.namespace.load('odkmaker.data');
         $('.workspace').empty();
 
         $('h1').text(formObj.title);
+        $('#formProperties_title').val(formObj.metadata.htitle)
         odkmaker.i18n.setActiveLanguages(formObj.metadata.activeLanguages);
         odkmaker.options.presets = formObj.metadata.optionsPresets;
         loadMany($('.workspace'), formObj.controls);
@@ -579,7 +591,7 @@ var dataNS = odkmaker.namespace.load('odkmaker.data');
                 {   name: 'h:head',
                     children: [
                         {   name: 'h:title',
-                            val: internal.title },
+                            val: odkmaker.data.getTitle() },
                         model
                     ] },
                 body

--- a/public/javascripts/modals.js
+++ b/public/javascripts/modals.js
@@ -70,6 +70,12 @@ var modalsNS = odkmaker.namespace.load('odkmaker.modals');
         {
             $dialog.removeClass('exporting');
         },
+        formPropertiesDialog: function($dialog)
+        {
+            $dialog.find('#formProperties_title')
+                .attr('placeholder', $('h1').text())
+                .val(odkmaker.data.getTitle());
+        },
         optionsEditorDialog: odkmaker.options.modalHandler
     };
 

--- a/public/stylesheets/styles.css
+++ b/public/stylesheets/styles.css
@@ -1213,6 +1213,12 @@ body > .control.last .controlFlowArrow,
     width: 40em;
 }
 
+.formPropertiesDialog input
+{
+    margin-left: 10em;
+    width: calc(100% - 10em);
+}
+
 .errorMessage p
 {
     color: #f00;

--- a/server/views/index.erb
+++ b/server/views/index.erb
@@ -79,7 +79,8 @@
             <li class="disabled"><a href="#undo">Undo</a></li>
             <li class="disabled"><a href="#redo">Redo</a></li>
             <li class="divider"></li>
-            <li><a href="#translationsDialog" class="manageTranslations" rel="modal">Manage Translations...</a></li>
+            <li><a href="#translationsDialog" class="manageTranslations" rel="modal">Manage Translations&hellip;</a></li>
+            <li><a href="#formPropertiesDialog" class="formProperties" rel="modal">Form Properties&hellip;</a></li>
           </ul>
         </li>
         <li>
@@ -288,6 +289,21 @@
       </div>
       <div class="modalButtonContainer">
         <a class="modalButton downloadLink" href="#download">Download</a>
+        <a class="modalButton jqmClose" href="#close">Done</a>
+      </div>
+    </div>
+
+    <div class="modal narrowModal formPropertiesDialog">
+      <h3>Form Properties</h3>
+      <div class="modalContents">
+        <form>
+          <div class="errorMessage"></div>
+
+          <label for="formProperties_title">Title on Phone</label>
+          <input type="text" id="formProperties_title" name="title" />
+        </form>
+      </div>
+      <div class="modalButtonContainer">
         <a class="modalButton jqmClose" href="#close">Done</a>
       </div>
     </div>

--- a/server/views/index.erb
+++ b/server/views/index.erb
@@ -299,7 +299,7 @@
         <form>
           <div class="errorMessage"></div>
 
-          <label for="formProperties_title">Title on Phone</label>
+          <label for="formProperties_title">Title on Device</label>
           <input type="text" id="formProperties_title" name="title" />
         </form>
       </div>


### PR DESCRIPTION
* the setting is found in the restored Form Properties dialog, under
  the Edit menu.
* the main form title is used if no title-on-phone is given.
* this commit is ugly as hell and full of hacks. but it’s the best i can
  do with this codebase.
* resolves #56.