### PR TITLE
nginx: update letsencrypt root path so that it actually works.

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -133,8 +133,8 @@
               proxy_pass: "http://[::1]:8686"
             location4:
               name: "~ ^/.well-known"
-              root: "/var/www/letsencrypt"
-              error_page: "404 =500 @500"
+              root: "/var/www"
+              error_page: "404 =500"
         - server:
             name: https
             listen: "443 ssl"


### PR DESCRIPTION
* was configured based off docs to look at
  /var/www/letsencrypt/.well-known/...
  but the tool writes the challenge file directly to
  /var/www/.well-known/...
  so we oblige and change nginx to look there.
* also removed a faulty @500 directive.