### PR TITLE
control/bug: xml export would fail with typeless media control.

### DIFF
--- a/public/javascripts/control.js
+++ b/public/javascripts/control.js
@@ -499,7 +499,8 @@
                         description: 'Type of media to upload.',
                         options: [ 'Image',
                                    'Audio',
-                                   'Video' ] } },
+                                   'Video' ],
+                        value: 'Image' } },
         inputBarcode: {},
         inputSelectOne: {
           options:    { name: 'Options',


### PR DESCRIPTION
* so enforce a type, like we do elsewhere.

just a little bug i found while testing other things.