### PR TITLE
Allow upload to HTTP-only Aggregate

### DIFF
--- a/public/javascripts/data-ui.js
+++ b/public/javascripts/data-ui.js
@@ -264,6 +264,7 @@ var dataNS = odkmaker.namespace.load('odkmaker.data');
             event.preventDefault();
 
             var $loading = $('.aggregateDialog .modalLoadingOverlay');
+            var protocol = $('.aggregateInstanceProtocol').val();
             var target = $('.aggregateInstanceName').val();
             $loading.show();
             $('.aggregateDialog .errorMessage').empty().hide();
@@ -272,7 +273,7 @@ var dataNS = odkmaker.namespace.load('odkmaker.data');
                 url: '/aggregate/post',
                 dataType: 'json',
                 type: 'POST',
-                data: { target: target, credentials: { user: $('#aggregateUser').val(), password: $('#aggregatePassword').val() }, name: $('h1').text(), payload: odkmaker.data.serialize() },
+                data: { protocol: protocol, target: target, credentials: { user: $('#aggregateUser').val(), password: $('#aggregatePassword').val() }, name: $('h1').text(), payload: odkmaker.data.serialize() },
                 success: function(response, status)
                 {
                     $.toast('Your form has been successfully uploaded to ' + $.h(target) + '.');

--- a/public/javascripts/data-ui.js
+++ b/public/javascripts/data-ui.js
@@ -287,6 +287,8 @@ var dataNS = odkmaker.namespace.load('odkmaker.data');
                         message = '<p>Could not upload the form. Aggregate could not validate the form contents. Please make sure your form is valid and try again.</p>';
                     else if (errorBody.code == '404')
                         message = '<p>Could not upload the form, because we could not find the Aggregate server you specified. Please check the address and try again.</p>';
+                    else if (errorBody.code == 'ECONNREFUSED')
+                        message = '<p>Could not upload the form. We found the server you specified, but it does not appear to be a valid, functioning Aggregate server. Please check the address and the server, and try again.</p>';
                     else
                         message = '<p>Could not upload the form. Please check your credentials and instance name, and try again.</p>';
 

--- a/public/stylesheets/styles.css
+++ b/public/stylesheets/styles.css
@@ -1357,7 +1357,7 @@ body > .control.last .controlFlowArrow,
 
 .aggregateDialog .aggregateInstanceName
 {
-    width: calc(100% - 5.2em);
+    width: calc(100% - 7.6em);
 }
 .aggregateDialog .note
 {

--- a/server/odkbuild_server.rb
+++ b/server/odkbuild_server.rb
@@ -247,7 +247,7 @@ class OdkBuild < Sinatra::Application
     return error_validation_failed unless params[:credentials][:user]
     return error_validation_failed unless params[:credentials][:password]
 
-    uri = URI.parse("https://#{params[:target]}/formUpload")
+    uri = URI.parse("#{params[:protocol] || 'https'}://#{params[:target]}/formUpload")
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true
     req = Net::HTTP::Post.new(uri.request_uri)

--- a/server/odkbuild_server.rb
+++ b/server/odkbuild_server.rb
@@ -264,6 +264,9 @@ class OdkBuild < Sinatra::Application
     rescue SocketError => ex
       status 404
       return { :error => ex.message, :code => 404, :body => 'Socket Error' }.to_json
+    rescue Errno::ECONNREFUSED => ex
+      status 400
+      return { :error => 'Errno::ECONNREFUSED', :code => 'ECONNREFUSED', :body => 'Connection refused' }.to_json
     end
 
     if res.code.to_s == '401'

--- a/server/views/index.erb
+++ b/server/views/index.erb
@@ -361,9 +361,13 @@
           visible on the Internet.</p>
 
         <h4>Aggregate Instance URI</h4>
-        <p>https://<input type="text" class="aggregateInstanceName"/></p>
+        <p>
+          <select class="aggregateInstanceProtocol">
+            <option>https</option>
+            <option>http</option>
+          </select>://<input type="text" class="aggregateInstanceName"/></p>
         <p>Examples include <code>https://my-aggregate.appspot.com</code> if you're on
-          Google App Engine, or <code>https://216.58.193.110:8080/ODKAggregate</code> if
+          Google App Engine, or <code>http://216.58.193.110:8080/ODKAggregate</code> if
           you have your own server on the web.</p>
         <h4>Aggregate Credentials</h4>
         <p>


### PR DESCRIPTION
Resolves #54.

A bonus commit traps a failure case found during testing of this change, wherein specifying a valid DNS address which fails to respond to :443 or :80 as expected causes a 500. Replaces that with a usefulish error message.