### PR TITLE
server/bug #106: don't throw a 500 if reset password user is NPE.

### DIFF
--- a/server/odkbuild_server.rb
+++ b/server/odkbuild_server.rb
@@ -179,6 +179,8 @@ class OdkBuild < Sinatra::Application
 
   post '/reset_password' do
     user = User.find_by_login_or_email params[:username]
+    return error_not_found if user.nil?
+
     new_password = user.reset_password!
     user.save
 


### PR DESCRIPTION
* that was embarrassingly simple.
* resolves #106.