### PR TITLE
Fix upload to Aggregate via plain (unsecured) HTTP

### DIFF
--- a/server/odkbuild_server.rb
+++ b/server/odkbuild_server.rb
@@ -249,9 +249,10 @@ class OdkBuild < Sinatra::Application
     return error_validation_failed unless params[:credentials][:user]
     return error_validation_failed unless params[:credentials][:password]
 
-    uri = URI.parse("#{params[:protocol] || 'https'}://#{params[:target]}/formUpload")
+    protocol = params[:protocol] || 'https'
+    uri = URI.parse("#{protocol}://#{params[:target]}/formUpload")
     http = Net::HTTP.new(uri.host, uri.port)
-    http.use_ssl = true
+    http.use_ssl = protocol == 'https'
     req = Net::HTTP::Post.new(uri.request_uri)
 
     body, headers = Multipart::Post.prepare_query({ 'form_name' => params[:name], 'form_def_file' => { :filename => 'form.xml', :content => params[:payload] } })


### PR DESCRIPTION
This PR aims to fix uploading form to Aggregate via plain (unsecured) HTTP. This is currently not possible as this part of code
https://github.com/opendatakit/build/blob/283da5840c7f83adf8228c558311266723b83fc1/server/odkbuild_server.rb#L252-L255
forces `http.use_ssl = true` every time, resulting in OpenSSL handshake error on plain HTTP.