### PR TITLE
improve: use uid preload for stable instanceIDs

### DIFF
--- a/public/javascripts/data.js
+++ b/public/javascripts/data.js
@@ -732,7 +732,7 @@ var dataNS = odkmaker.namespace.load('odkmaker.data');
                 'nodeset': '/data/meta/instanceID',
                 'type' : 'string',
                 'readonly' : 'true()',
-                'calculate' : 'concat(\'uuid:\', uuid())'
+                'jr:preload' : 'uid'
             }
         }
         model.children.push(instanceID);


### PR DESCRIPTION
Closes #228

Warning: I have not tried this.

@issa-tseng Our conversation about `instanceID` in the context of Central made me think of this. As you can see, this explains why servers don't have to think too much about `instanceID` collisions -- the IDs are not actually stable across form edit sessions.

As there's talk of better supporting edit workflows and links between forms, stable `instanceID`s become important. This change will happen in `pyxform` soon and since there's a Build release pending, I thought I'd try to squeeze this in at the 23:59th hour...

Feel free to do your own commit if you don't like my commit message or if it's wrong in some way. Or if you'd rather not squeeze something like this in, I understand.